### PR TITLE
feat: add chat summary slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
 - /라라 커맨드로 질문을 입력
 <img width="550" height="105" alt="image" src="https://github.com/user-attachments/assets/e9776dd4-b9f4-4f1a-a842-0dee1215a3bd" />
 
+## 채팅 요약
+- `/채팅날짜` 커맨드로 요약 가능한 날짜 목록을 조회
+- `/채팅요약 date:YYYY-MM-DD` 커맨드로 특정 날짜의 메신저 내용을 요약
+- MCP 서버는 `POST /mcp` 로 호출하며, 응답이 2000자를 넘으면 Discord 메시지를 분할 전송
+
 
 <img width="550" height="440" alt="image" src="https://github.com/user-attachments/assets/3cbc688e-4df5-4062-96c6-4f7e49e109e9" />
 

--- a/backend/src/main/java/com/discord_bot/backend/common/config/BotConfig.java
+++ b/backend/src/main/java/com/discord_bot/backend/common/config/BotConfig.java
@@ -19,6 +19,16 @@ import com.discord_bot.backend.common.listener.DiscordListener;
 @Configuration
 public class BotConfig {
 
+	private static final String COMMAND_STOCK = "주식";
+	private static final String COMMAND_CHAT = "라라";
+	private static final String COMMAND_PARTY = "파티";
+	private static final String COMMAND_DICE = "주사위";
+	private static final String COMMAND_CHAT_DATES = "채팅날짜";
+	private static final String COMMAND_CHAT_SUMMARY = "채팅요약";
+	private static final String OPTION_QUESTION = "질문";
+	private static final String OPTION_LIMIT = "limit";
+	private static final String OPTION_DATE = "date";
+
 	private final ApplicationContext context;
 
 	public BotConfig(ApplicationContext context) {
@@ -27,11 +37,10 @@ public class BotConfig {
 
 	@Value("${discord.token}")
 	private String token;
-	private JDA jda;
 
 	@Bean
 	public JDA jdaBuilder() throws LoginException, InterruptedException {
-		jda = JDABuilder.createDefault(token)
+		JDA jda = JDABuilder.createDefault(token)
 			.setActivity(Activity.playing("라라 대기중..."))
 			.enableIntents(GatewayIntent.MESSAGE_CONTENT)
 			.addEventListeners(context.getBean(DiscordListener.class))
@@ -40,12 +49,16 @@ public class BotConfig {
 		jda.awaitReady();
 
 		jda.updateCommands().addCommands(
-			Commands.slash("주식", "종목 시세 조회")
+			Commands.slash(COMMAND_STOCK, "종목 시세 조회")
 				.addOption(OptionType.STRING, "query", "종목명 검색", true, true),
-			Commands.slash("라라", "라라봇에게 질문합니다")
-				.addOption(OptionType.STRING, "질문", "질문 내용을 입력해주세요", true),
-			Commands.slash("파티", "파티짜줘 링크를 보여줍니다"),
-			Commands.slash("주사위", "주사위 게임을 시작합니다")
+			Commands.slash(COMMAND_CHAT, "라라봇에게 질문합니다")
+				.addOption(OptionType.STRING, OPTION_QUESTION, "질문 내용을 입력해주세요", true),
+			Commands.slash(COMMAND_PARTY, "파티짜줘 링크를 보여줍니다"),
+			Commands.slash(COMMAND_DICE, "주사위 게임을 시작합니다"),
+			Commands.slash(COMMAND_CHAT_DATES, "요약 가능한 채팅 날짜를 조회합니다")
+				.addOption(OptionType.INTEGER, OPTION_LIMIT, "조회할 날짜 개수 (기본값 10)", false),
+			Commands.slash(COMMAND_CHAT_SUMMARY, "특정 날짜의 채팅 내용을 요약합니다")
+				.addOption(OptionType.STRING, OPTION_DATE, "요약할 날짜 (YYYY-MM-DD)", true)
 		).queue();
 
 		return jda;

--- a/backend/src/main/java/com/discord_bot/backend/common/listener/DiscordListener.java
+++ b/backend/src/main/java/com/discord_bot/backend/common/listener/DiscordListener.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +47,7 @@ import net.dv8tion.jda.api.interactions.commands.Command;
 
 import com.discord_bot.backend.common.kafka.DiscordEventProducer;
 import com.discord_bot.backend.common.kafka.model.dto.BotEventRequestDto;
+import com.discord_bot.backend.domain.chat.service.ChatSummaryService;
 import com.discord_bot.backend.domain.chat.service.GPTService;
 import com.discord_bot.backend.domain.music.service.AudioService;
 import com.discord_bot.backend.domain.stablediffusion.service.ImageService;
@@ -63,7 +66,19 @@ import okhttp3.Response;
 @RequiredArgsConstructor
 public class DiscordListener extends ListenerAdapter {
 
+	private static final String COMMAND_STOCK = "주식";
+	private static final String COMMAND_CHAT = "라라";
+	private static final String COMMAND_PARTY = "파티";
+	private static final String COMMAND_DICE = "주사위";
+	private static final String COMMAND_CHAT_DATES = "채팅날짜";
+	private static final String COMMAND_CHAT_SUMMARY = "채팅요약";
+	private static final String OPTION_QUESTION = "질문";
+	private static final String OPTION_LIMIT = "limit";
+	private static final String OPTION_DATE = "date";
+	private static final int DISCORD_MESSAGE_LIMIT = 2000;
+
 	private final AudioService audioService;
+	private final ChatSummaryService chatSummaryService;
 	private final GPTService gptService;
 	private final ImageService imageService;
 	private final StockSearchService stockSearchService;
@@ -117,7 +132,7 @@ public class DiscordListener extends ListenerAdapter {
 	@Override
 	public void onCommandAutoCompleteInteraction(@NotNull CommandAutoCompleteInteractionEvent event) {
 
-		if (!event.getName().equals("주식"))
+		if (!event.getName().equals(COMMAND_STOCK))
 			return;
 
 		String q = event.getFocusedOption().getValue().trim();
@@ -143,22 +158,30 @@ public class DiscordListener extends ListenerAdapter {
 	public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
 
 		switch (event.getName()) {
-			case "주식" -> {
+			case COMMAND_STOCK -> {
 				handleStockSlashCommand(event);
 			}
-			case "라라" -> {
-				String question = event.getOption("질문").getAsString().trim();
+			case COMMAND_CHAT -> {
+				String question = event.getOption(OPTION_QUESTION).getAsString().trim();
 				event.deferReply().queue();
 				handleGptSlashCommand(question, event);
 			}
-			case "파티" -> event.reply("https://partycontrol.duckdns.org/").queue();
-			case "주사위" -> {
+			case COMMAND_PARTY -> event.reply("https://partycontrol.duckdns.org/").queue();
+			case COMMAND_DICE -> {
 				startDiceGame(event);
+			}
+			case COMMAND_CHAT_DATES -> {
+				event.deferReply().queue();
+				handleChatDatesSlashCommand(event);
+			}
+			case COMMAND_CHAT_SUMMARY -> {
+				event.deferReply().queue();
+				handleChatSummarySlashCommand(event);
 			}
 		}
 		Member member = event.getMember();
 		BotEventRequestDto slashDto = BotEventRequestDto.builder()
-			.userName(member.getEffectiveName())
+			.userName(member != null ? member.getEffectiveName() : event.getUser().getName())
 			.channelName(event.getChannel().getName())
 			.channelId(event.getChannel().getIdLong())
 			.element(event.getName())
@@ -210,6 +233,75 @@ public class DiscordListener extends ListenerAdapter {
 			event.getHook().editOriginal("시세 조회 중 오류가 발생했어요 ").queue();
 			log.info(e.getMessage());
 		}
+	}
+
+	private void handleChatDatesSlashCommand(SlashCommandInteractionEvent event) {
+		Integer limit = event.getOption(OPTION_LIMIT) != null
+			? Math.toIntExact(event.getOption(OPTION_LIMIT).getAsLong())
+			: null;
+
+		CompletableFuture
+			.supplyAsync(() -> chatSummaryService.getAvailableDates(limit))
+			.thenAccept(response -> sendChunkedReply(event, response))
+			.exceptionally(ex -> {
+				log.error("Failed to process chat date list request", ex);
+				event.getHook().editOriginal("요청 처리 중 오류가 발생했습니다.").queue();
+				return null;
+			});
+	}
+
+	private void handleChatSummarySlashCommand(SlashCommandInteractionEvent event) {
+		String date = event.getOption(OPTION_DATE).getAsString().trim();
+
+		try {
+			LocalDate.parse(date);
+		} catch (DateTimeParseException e) {
+			event.getHook().editOriginal("날짜는 YYYY-MM-DD 형식으로 입력해주세요.").queue();
+			return;
+		}
+
+		CompletableFuture
+			.supplyAsync(() -> chatSummaryService.summarizeChat(date))
+			.thenAccept(response -> sendChunkedReply(event, response))
+			.exceptionally(ex -> {
+				log.error("Failed to process chat summary request. date={}", date, ex);
+				event.getHook().editOriginal("요청 처리 중 오류가 발생했습니다.").queue();
+				return null;
+			});
+	}
+
+	private void sendChunkedReply(SlashCommandInteractionEvent event, String message) {
+		List<String> chunks = splitMessage(message);
+		if (chunks.isEmpty()) {
+			event.getHook().editOriginal("전달할 내용이 없습니다.").queue();
+			return;
+		}
+
+		event.getHook().editOriginal(chunks.get(0)).queue();
+		for (int i = 1; i < chunks.size(); i++) {
+			event.getHook().sendMessage(chunks.get(i)).queue();
+		}
+	}
+
+	private List<String> splitMessage(String message) {
+		if (message == null || message.isBlank()) {
+			return List.of();
+		}
+
+		List<String> chunks = new java.util.ArrayList<>();
+		String remaining = message;
+		while (remaining.length() > DISCORD_MESSAGE_LIMIT) {
+			int splitIndex = remaining.lastIndexOf('\n', DISCORD_MESSAGE_LIMIT);
+			if (splitIndex <= 0) {
+				splitIndex = DISCORD_MESSAGE_LIMIT;
+			}
+			chunks.add(remaining.substring(0, splitIndex));
+			remaining = remaining.substring(splitIndex).stripLeading();
+		}
+		if (!remaining.isBlank()) {
+			chunks.add(remaining);
+		}
+		return chunks;
 	}
 
 	/**
@@ -430,6 +522,8 @@ public class DiscordListener extends ListenerAdapter {
 				+ "1. gpt사용 !라라 + 질문내용\n"
 				+ "2. 주사위게임 !데굴데굴\n"
 				+ "3. 파티짜줘 !파티\n"
+				+ "4. 채팅날짜 /채팅날짜 [limit]\n"
+				+ "5. 채팅요약 /채팅요약 date:YYYY-MM-DD\n"
 				+ "```").queue(); // 알림 메시지
 		} catch (Exception e) {
 			event.getChannel().sendMessage("오류가 발생하여 도움말을 불러오지못했습니다").queue(); // 예외 처리

--- a/backend/src/main/java/com/discord_bot/backend/domain/chat/dto/McpToolCallParams.java
+++ b/backend/src/main/java/com/discord_bot/backend/domain/chat/dto/McpToolCallParams.java
@@ -1,0 +1,33 @@
+package com.discord_bot.backend.domain.chat.dto;
+
+import java.util.Map;
+
+public class McpToolCallParams {
+
+	private String name;
+	private Map<String, Object> arguments;
+
+	public McpToolCallParams() {
+	}
+
+	public McpToolCallParams(String name, Map<String, Object> arguments) {
+		this.name = name;
+		this.arguments = arguments;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Map<String, Object> getArguments() {
+		return arguments;
+	}
+
+	public void setArguments(Map<String, Object> arguments) {
+		this.arguments = arguments;
+	}
+}

--- a/backend/src/main/java/com/discord_bot/backend/domain/chat/dto/McpToolCallRequest.java
+++ b/backend/src/main/java/com/discord_bot/backend/domain/chat/dto/McpToolCallRequest.java
@@ -1,0 +1,51 @@
+package com.discord_bot.backend.domain.chat.dto;
+
+public class McpToolCallRequest {
+
+	private String jsonrpc;
+	private String id;
+	private String method;
+	private McpToolCallParams params;
+
+	public McpToolCallRequest() {
+	}
+
+	public McpToolCallRequest(String jsonrpc, String id, String method, McpToolCallParams params) {
+		this.jsonrpc = jsonrpc;
+		this.id = id;
+		this.method = method;
+		this.params = params;
+	}
+
+	public String getJsonrpc() {
+		return jsonrpc;
+	}
+
+	public void setJsonrpc(String jsonrpc) {
+		this.jsonrpc = jsonrpc;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getMethod() {
+		return method;
+	}
+
+	public void setMethod(String method) {
+		this.method = method;
+	}
+
+	public McpToolCallParams getParams() {
+		return params;
+	}
+
+	public void setParams(McpToolCallParams params) {
+		this.params = params;
+	}
+}

--- a/backend/src/main/java/com/discord_bot/backend/domain/chat/service/ChatSummaryService.java
+++ b/backend/src/main/java/com/discord_bot/backend/domain/chat/service/ChatSummaryService.java
@@ -1,0 +1,159 @@
+package com.discord_bot.backend.domain.chat.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.discord_bot.backend.domain.chat.dto.McpToolCallParams;
+import com.discord_bot.backend.domain.chat.dto.McpToolCallRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatSummaryService {
+
+	private static final String MCP_REQUEST_ERROR_MESSAGE = "요청 처리 중 오류가 발생했습니다.";
+	private static final int DEFAULT_DATE_LIMIT = 10;
+	private static final int SUMMARY_LIMIT = 3000;
+
+	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Value("${mcp.chat.url}")
+	private String mcpUrl;
+
+	public String getAvailableDates(Integer limit) {
+		int safeLimit = (limit == null || limit <= 0) ? DEFAULT_DATE_LIMIT : limit;
+		String responseText = callTool("list_chat_dates", Map.of("limit", safeLimit));
+		return formatDateList(responseText, safeLimit);
+	}
+
+	public String summarizeChat(String date) {
+		return callTool("analyze_chat_topics", Map.of(
+			"date", date,
+			"limit", SUMMARY_LIMIT
+		));
+	}
+
+	private String callTool(String toolName, Map<String, Object> arguments) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		McpToolCallRequest request = new McpToolCallRequest(
+			"2.0",
+			"discord-request",
+			"tools/call",
+			new McpToolCallParams(toolName, arguments)
+		);
+
+		try {
+			String responseBody = restTemplate.postForObject(
+				mcpUrl,
+				new HttpEntity<>(request, headers),
+				String.class
+			);
+
+			if (responseBody == null || responseBody.isBlank()) {
+				log.error("MCP response body is empty. tool={}", toolName);
+				throw new IllegalStateException(MCP_REQUEST_ERROR_MESSAGE);
+			}
+
+			JsonNode root = objectMapper.readTree(responseBody);
+			JsonNode errorNode = root.path("error");
+			if (!errorNode.isMissingNode() && !errorNode.isNull()) {
+				log.error("MCP tool returned error. tool={}, message={}", toolName, errorNode.path("message").asText());
+				throw new IllegalStateException(MCP_REQUEST_ERROR_MESSAGE);
+			}
+
+			JsonNode contentNode = root.path("result").path("content");
+			if (!contentNode.isArray() || contentNode.isEmpty()) {
+				log.error("MCP content node is missing. tool={}, response={}", toolName, responseBody);
+				throw new IllegalStateException(MCP_REQUEST_ERROR_MESSAGE);
+			}
+
+			String text = contentNode.get(0).path("text").asText("");
+			if (text.isBlank()) {
+				log.error("MCP content text is blank. tool={}, response={}", toolName, responseBody);
+				throw new IllegalStateException(MCP_REQUEST_ERROR_MESSAGE);
+			}
+
+			return text;
+		} catch (JsonProcessingException e) {
+			log.error("Failed to parse MCP response. tool={}", toolName, e);
+			throw new IllegalStateException(MCP_REQUEST_ERROR_MESSAGE, e);
+		} catch (RestClientException e) {
+			log.error("Failed to call MCP server. tool={}, url={}", toolName, mcpUrl, e);
+			throw new IllegalStateException(MCP_REQUEST_ERROR_MESSAGE, e);
+		}
+	}
+
+	private String formatDateList(String responseText, int limit) {
+		List<String> dates = extractDates(responseText);
+		if (dates.isEmpty()) {
+			return responseText;
+		}
+
+		StringBuilder builder = new StringBuilder("요약 가능한 채팅 날짜입니다.\n");
+		for (int i = 0; i < Math.min(dates.size(), limit); i++) {
+			builder.append(i + 1)
+				.append(". ")
+				.append(dates.get(i))
+				.append('\n');
+		}
+		builder.append("\n원하는 날짜로 /채팅요약 date:YYYY-MM-DD 를 사용해주세요.");
+		return builder.toString().trim();
+	}
+
+	private List<String> extractDates(String responseText) {
+		try {
+			JsonNode root = objectMapper.readTree(responseText);
+			Set<String> dates = new LinkedHashSet<>();
+			collectDates(root, dates);
+			return new ArrayList<>(dates);
+		} catch (JsonProcessingException e) {
+			log.warn("Failed to parse date list response text as JSON. raw={}", responseText);
+			return List.of();
+		}
+	}
+
+	private void collectDates(JsonNode node, Set<String> dates) {
+		if (node == null || node.isNull()) {
+			return;
+		}
+
+		if (node.isTextual()) {
+			String value = node.asText().trim();
+			if (value.matches("\\d{4}-\\d{2}-\\d{2}")) {
+				dates.add(value);
+			}
+			return;
+		}
+
+		if (node.isArray()) {
+			for (JsonNode child : node) {
+				collectDates(child, dates);
+			}
+			return;
+		}
+
+		if (node.isObject()) {
+			node.fields().forEachRemaining(entry -> collectDates(entry.getValue(), dates));
+		}
+	}
+}

--- a/backend/src/main/resources/application-security.yml
+++ b/backend/src/main/resources/application-security.yml
@@ -38,6 +38,10 @@ discord:
 fastapi:
   url: ${FASTAPI_URL}
 
+mcp:
+  chat:
+    url: ${MCP_CHAT_URL}
+
 gpt:
   api:
     key: ${GPT_KEY}

--- a/backend/src/test/java/com/discord_bot/backend/domain/chat/service/ChatSummaryServiceTest.java
+++ b/backend/src/test/java/com/discord_bot/backend/domain/chat/service/ChatSummaryServiceTest.java
@@ -1,0 +1,130 @@
+package com.discord_bot.backend.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ChatSummaryServiceTest {
+
+	private static final String MCP_URL = "http://localhost:18000/mcp";
+
+	private ChatSummaryService chatSummaryService;
+	private MockRestServiceServer mockServer;
+
+	@BeforeEach
+	void setUp() {
+		RestTemplate restTemplate = new RestTemplate();
+		mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+
+		chatSummaryService = new ChatSummaryService(restTemplate, new ObjectMapper());
+		ReflectionTestUtils.setField(chatSummaryService, "mcpUrl", MCP_URL);
+	}
+
+	@Test
+	void getAvailableDates_formatsDateListFromMcpResponse() {
+		mockServer.expect(requestTo(MCP_URL))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(content().json("""
+				{
+				  "jsonrpc": "2.0",
+				  "id": "discord-request",
+				  "method": "tools/call",
+				  "params": {
+				    "name": "list_chat_dates",
+				    "arguments": {
+				      "limit": 3
+				    }
+				  }
+				}
+				"""))
+			.andRespond(withSuccess("""
+				{
+				  "jsonrpc": "2.0",
+				  "result": {
+				    "content": [
+				      {
+				        "text": "[\\\"2026-06-10\\\",\\\"2026-06-09\\\",\\\"2026-06-08\\\"]"
+				      }
+				    ]
+				  }
+				}
+				""", MediaType.APPLICATION_JSON));
+
+		String result = chatSummaryService.getAvailableDates(3);
+
+		assertThat(result).contains("1. 2026-06-10");
+		assertThat(result).contains("2. 2026-06-09");
+		assertThat(result).contains("/채팅요약 date:YYYY-MM-DD");
+		mockServer.verify();
+	}
+
+	@Test
+	void summarizeChat_returnsRawTextFromMcpResponse() {
+		mockServer.expect(requestTo(MCP_URL))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(content().json("""
+				{
+				  "jsonrpc": "2.0",
+				  "id": "discord-request",
+				  "method": "tools/call",
+				  "params": {
+				    "name": "analyze_chat_topics",
+				    "arguments": {
+				      "date": "2026-06-10",
+				      "limit": 3000
+				    }
+				  }
+				}
+				"""))
+			.andRespond(withSuccess("""
+				{
+				  "jsonrpc": "2.0",
+				  "result": {
+				    "content": [
+				      {
+				        "text": "요약 결과 본문"
+				      }
+				    ]
+				  }
+				}
+				""", MediaType.APPLICATION_JSON));
+
+		String result = chatSummaryService.summarizeChat("2026-06-10");
+
+		assertThat(result).isEqualTo("요약 결과 본문");
+		mockServer.verify();
+	}
+
+	@Test
+	void summarizeChat_throwsUserFriendlyMessageWhenMcpReturnsError() {
+		mockServer.expect(requestTo(MCP_URL))
+			.andExpect(method(HttpMethod.POST))
+			.andRespond(withSuccess("""
+				{
+				  "jsonrpc": "2.0",
+				  "error": {
+				    "message": "internal failure"
+				  }
+				}
+				""", MediaType.APPLICATION_JSON));
+
+		assertThatThrownBy(() -> chatSummaryService.summarizeChat("2026-06-10"))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("요청 처리 중 오류가 발생했습니다.");
+
+		mockServer.verify();
+	}
+}


### PR DESCRIPTION
## Summary
- add `/채팅날짜` and `/채팅요약` slash commands
- integrate Discord bot with MCP chat summary tools
- split long MCP responses for Discord and add service-level tests

## Testing
- `./gradlew.bat test --tests com.discord_bot.backend.domain.chat.service.ChatSummaryServiceTest`